### PR TITLE
Spike geth instrumenter

### DIFF
--- a/docs/notes/instrumentation_measurement/example_bytecode_programs.md
+++ b/docs/notes/instrumentation_measurement/example_bytecode_programs.md
@@ -1,0 +1,7 @@
+## Example bytecode programs
+
+This is just a quick dump of simple, working programs to smoke test stuff with:
+
+- `6020` - just push
+- `602060070260F053600160F0F3` - push, mul and return
+- `62FFFFFF600020` - some keccak

--- a/docs/notes/instrumentation_measurement/geth.md
+++ b/docs/notes/instrumentation_measurement/geth.md
@@ -20,6 +20,10 @@
     - (optional) implement an Analysis tool to detect problems with uneven overhead of instrumentation (e.g. every program has Nth instruction exceedingly costly, because our `Tracer` is doing something)
     - (for Stage II) implement a `Tracer` satisfying all the criteria
     - (for Stage II) ensure the `steps%1000` line (see rough notes below) doesn't affect us
+3. `Tracer.CaptureState` layout in `interpreter.go` must be altered, because otherwise time measurements captured will be skewed (measure two neighboring instructions mixed)
+4. Care must be taken with warm-up.
+    - If you warm up with tracing off, weird effects happen - first traced execution of `SHA3` gets a huge result.
+    - Warm-up still doesn't alleviate the effect of multiple occurrence of `SHA3` instruction in a single program - first one is always more costly.
 
 
 ### Rough notes

--- a/docs/notes/instrumentation_measurement/geth.md
+++ b/docs/notes/instrumentation_measurement/geth.md
@@ -7,6 +7,7 @@
     - we should investigate the overhead of some operations before entering the interpreter loop happening after `CaptureStart` (see rough notes)
     - we should remember to implement or `Tracer` so that it's operation has smallest overhead (e.g. make sure it doesn't suddenly allocate stuff after N instructions, or produce other fluctuations). We should have steps in the Analysis toolbox that would detect such problems.
     - it should be relatively easy to write a `Tracer` implementation which does what we want
+    - we're removing all storage and stack tracking. Storage is out of scope and stack we'll do with the vanilla `StructLogger` (if necessary); it requires access to `vm` package internals. Same with memory and return data tracing for consistency
 2. New tasks:
     - (to do immediately) spike an instrumenting `Tracer` which measures Nth instruction clock time, in terms of `program counter`/`pc`
     - investigate the overhead of some operations before entering the interpreter loop happening after `CaptureStart` (see rough notes). Remove these operations and compare measurements. If necessary, implement a fork of `go-ethereum` where the impact is minimized

--- a/docs/notes/instrumentation_measurement/geth.md
+++ b/docs/notes/instrumentation_measurement/geth.md
@@ -13,8 +13,10 @@
     - we should remember to implement or `Tracer` so that it's operation has smallest overhead (e.g. make sure it doesn't suddenly allocate stuff after N instructions, or produce other fluctuations). We should have steps in the Analysis toolbox that would detect such problems.
     - it should be relatively easy to write a `Tracer` implementation which does what we want
     - we're removing all storage and stack tracking. Storage is out of scope and stack we'll do with the vanilla `StructLogger` (if necessary); it requires access to `vm` package internals. Same with memory and return data tracing for consistency
-2. New tasks:
-    - (to do immediately) spike an instrumenting `Tracer` which measures Nth instruction clock time, in terms of `program counter`/`pc`
+2. New tasks (**TODO**):
+    - tidy up `main.go` and `instrumenter.go` code, possibly draft some simple unit test before adding more functionality
+    - properly fork and manage the `go-ethereum` dependency
+    - implement standardized output from instrumentation (as per [strategy.md](/docs/strategy.md))
     - investigate the overhead of some operations before entering the interpreter loop happening after `CaptureStart` (see rough notes). Remove these operations and compare measurements. If necessary, implement a fork of `go-ethereum` where the impact is minimized
     - ensure `Tracer` implementation has negligible and even overhead (e.g. make sure it doesn't suddenly allocate stuff after N instructions, or produce other fluctuations)
     - (optional) implement an Analysis tool to detect problems with uneven overhead of instrumentation (e.g. every program has Nth instruction exceedingly costly, because our `Tracer` is doing something)

--- a/docs/notes/instrumentation_measurement/geth.md
+++ b/docs/notes/instrumentation_measurement/geth.md
@@ -1,5 +1,10 @@
 # Instrumentation and measurement using `go-ethereum` (`geth`)
 
+### Usage of `interpreter.go`
+
+0. Need to use `go-ethereum` with moved `CaptureState` in `github.com/ethereum/go-ethereum/core/vm/interpreter.go`, `CaptureState` must be after `execute`
+1. `GOGC=off go run main.go --bytecode 62FFFFFF60002062FFFFFF600020`
+
 ### Take aways
 
 1. `Tracer` interface (and `StructLogger` being a template implementation) is a good instrumenter

--- a/docs/notes/instrumentation_measurement/geth/instrumenter/instrumenter.go
+++ b/docs/notes/instrumentation_measurement/geth/instrumenter/instrumenter.go
@@ -1,0 +1,365 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package vm
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var errTraceLimitReached = errors.New("the number of logs reached the specified limit")
+
+// Storage represents a contract's storage.
+type Storage map[common.Hash]common.Hash
+
+// Copy duplicates the current storage.
+func (s Storage) Copy() Storage {
+	cpy := make(Storage)
+	for key, value := range s {
+		cpy[key] = value
+	}
+	return cpy
+}
+
+// LogConfig are the configuration options for structured logger the EVM
+type LogConfig struct {
+	DisableMemory     bool // disable memory capture
+	DisableStack      bool // disable stack capture
+	DisableStorage    bool // disable storage capture
+	DisableReturnData bool // disable return data capture
+	Debug             bool // print output during capture end
+	Limit             int  // maximum length of output, but zero means unlimited
+	// Chain overrides, can be used to execute a trace using future fork rules
+	Overrides *params.ChainConfig `json:"overrides,omitempty"`
+}
+
+//go:generate gencodec -type StructLog -field-override structLogMarshaling -out gen_structlog.go
+
+// StructLog is emitted to the EVM each cycle and lists information about the current internal state
+// prior to the execution of the statement.
+type StructLog struct {
+	Pc            uint64                      `json:"pc"`
+	Op            OpCode                      `json:"op"`
+	Gas           uint64                      `json:"gas"`
+	GasCost       uint64                      `json:"gasCost"`
+	Memory        []byte                      `json:"memory"`
+	MemorySize    int                         `json:"memSize"`
+	Stack         []*big.Int                  `json:"stack"`
+	ReturnStack   []uint32                    `json:"returnStack"`
+	ReturnData    []byte                      `json:"returnData"`
+	Storage       map[common.Hash]common.Hash `json:"-"`
+	Depth         int                         `json:"depth"`
+	RefundCounter uint64                      `json:"refund"`
+	Err           error                       `json:"-"`
+}
+
+// overrides for gencodec
+type structLogMarshaling struct {
+	Stack       []*math.HexOrDecimal256
+	ReturnStack []math.HexOrDecimal64
+	Gas         math.HexOrDecimal64
+	GasCost     math.HexOrDecimal64
+	Memory      hexutil.Bytes
+	ReturnData  hexutil.Bytes
+	OpName      string `json:"opName"` // adds call to OpName() in MarshalJSON
+	ErrorString string `json:"error"`  // adds call to ErrorString() in MarshalJSON
+}
+
+// OpName formats the operand name in a human-readable format.
+func (s *StructLog) OpName() string {
+	return s.Op.String()
+}
+
+// ErrorString formats the log's error as a string.
+func (s *StructLog) ErrorString() string {
+	if s.Err != nil {
+		return s.Err.Error()
+	}
+	return ""
+}
+
+// Tracer is used to collect execution traces from an EVM transaction
+// execution. CaptureState is called for each step of the VM with the
+// current VM state.
+// Note that reference types are actual VM data structures; make copies
+// if you need to retain them beyond the current call.
+type Tracer interface {
+	CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) error
+	CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, rStack *ReturnStack, rData []byte, contract *Contract, depth int, err error) error
+	CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, rStack *ReturnStack, contract *Contract, depth int, err error) error
+	CaptureEnd(output []byte, gasUsed uint64, t time.Duration, err error) error
+}
+
+// StructLogger is an EVM state logger and implements Tracer.
+//
+// StructLogger can capture state based on the given Log configuration and also keeps
+// a track record of modified storage which is used in reporting snapshots of the
+// contract their storage.
+type StructLogger struct {
+	cfg LogConfig
+
+	storage map[common.Address]Storage
+	logs    []StructLog
+	output  []byte
+	err     error
+}
+
+// NewStructLogger returns a new logger
+func NewStructLogger(cfg *LogConfig) *StructLogger {
+	logger := &StructLogger{
+		storage: make(map[common.Address]Storage),
+	}
+	if cfg != nil {
+		logger.cfg = *cfg
+	}
+	return logger
+}
+
+// CaptureStart implements the Tracer interface to initialize the tracing operation.
+func (l *StructLogger) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) error {
+	return nil
+}
+
+// CaptureState logs a new structured log message and pushes it out to the environment
+//
+// CaptureState also tracks SLOAD/SSTORE ops to track storage change.
+func (l *StructLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, rStack *ReturnStack, rData []byte, contract *Contract, depth int, err error) error {
+	// check if already accumulated the specified number of logs
+	if l.cfg.Limit != 0 && l.cfg.Limit <= len(l.logs) {
+		return errTraceLimitReached
+	}
+	// Copy a snapshot of the current memory state to a new buffer
+	var mem []byte
+	if !l.cfg.DisableMemory {
+		mem = make([]byte, len(memory.Data()))
+		copy(mem, memory.Data())
+	}
+	// Copy a snapshot of the current stack state to a new buffer
+	var stck []*big.Int
+	if !l.cfg.DisableStack {
+		stck = make([]*big.Int, len(stack.Data()))
+		for i, item := range stack.Data() {
+			stck[i] = new(big.Int).Set(item.ToBig())
+		}
+	}
+	var rstack []uint32
+	if !l.cfg.DisableStack && rStack != nil {
+		rstck := make([]uint32, len(rStack.data))
+		copy(rstck, rStack.data)
+	}
+	// Copy a snapshot of the current storage to a new container
+	var storage Storage
+	if !l.cfg.DisableStorage {
+		// initialise new changed values storage container for this contract
+		// if not present.
+		if l.storage[contract.Address()] == nil {
+			l.storage[contract.Address()] = make(Storage)
+		}
+		// capture SLOAD opcodes and record the read entry in the local storage
+		if op == SLOAD && stack.len() >= 1 {
+			var (
+				address = common.Hash(stack.data[stack.len()-1].Bytes32())
+				value   = env.StateDB.GetState(contract.Address(), address)
+			)
+			l.storage[contract.Address()][address] = value
+		}
+		// capture SSTORE opcodes and record the written entry in the local storage.
+		if op == SSTORE && stack.len() >= 2 {
+			var (
+				value   = common.Hash(stack.data[stack.len()-2].Bytes32())
+				address = common.Hash(stack.data[stack.len()-1].Bytes32())
+			)
+			l.storage[contract.Address()][address] = value
+		}
+		storage = l.storage[contract.Address()].Copy()
+	}
+	var rdata []byte
+	if !l.cfg.DisableReturnData {
+		rdata = make([]byte, len(rData))
+		copy(rdata, rData)
+	}
+	// create a new snapshot of the EVM.
+	log := StructLog{pc, op, gas, cost, mem, memory.Len(), stck, rstack, rdata, storage, depth, env.StateDB.GetRefund(), err}
+	l.logs = append(l.logs, log)
+	return nil
+}
+
+// CaptureFault implements the Tracer interface to trace an execution fault
+// while running an opcode.
+func (l *StructLogger) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, rStack *ReturnStack, contract *Contract, depth int, err error) error {
+	return nil
+}
+
+// CaptureEnd is called after the call finishes to finalize the tracing.
+func (l *StructLogger) CaptureEnd(output []byte, gasUsed uint64, t time.Duration, err error) error {
+	l.output = output
+	l.err = err
+	if l.cfg.Debug {
+		fmt.Printf("0x%x\n", output)
+		if err != nil {
+			fmt.Printf(" error: %v\n", err)
+		}
+	}
+	return nil
+}
+
+// StructLogs returns the captured log entries.
+func (l *StructLogger) StructLogs() []StructLog { return l.logs }
+
+// Error returns the VM error captured by the trace.
+func (l *StructLogger) Error() error { return l.err }
+
+// Output returns the VM return value captured by the trace.
+func (l *StructLogger) Output() []byte { return l.output }
+
+// WriteTrace writes a formatted trace to the given writer
+func WriteTrace(writer io.Writer, logs []StructLog) {
+	for _, log := range logs {
+		fmt.Fprintf(writer, "%-16spc=%08d gas=%v cost=%v", log.Op, log.Pc, log.Gas, log.GasCost)
+		if log.Err != nil {
+			fmt.Fprintf(writer, " ERROR: %v", log.Err)
+		}
+		fmt.Fprintln(writer)
+
+		if len(log.Stack) > 0 {
+			fmt.Fprintln(writer, "Stack:")
+			for i := len(log.Stack) - 1; i >= 0; i-- {
+				fmt.Fprintf(writer, "%08d  %x\n", len(log.Stack)-i-1, math.PaddedBigBytes(log.Stack[i], 32))
+			}
+		}
+		if len(log.ReturnStack) > 0 {
+			fmt.Fprintln(writer, "ReturnStack:")
+			for i := len(log.Stack) - 1; i >= 0; i-- {
+				fmt.Fprintf(writer, "%08d  0x%x (%d)\n", len(log.Stack)-i-1, log.ReturnStack[i], log.ReturnStack[i])
+			}
+		}
+		if len(log.Memory) > 0 {
+			fmt.Fprintln(writer, "Memory:")
+			fmt.Fprint(writer, hex.Dump(log.Memory))
+		}
+		if len(log.Storage) > 0 {
+			fmt.Fprintln(writer, "Storage:")
+			for h, item := range log.Storage {
+				fmt.Fprintf(writer, "%x: %x\n", h, item)
+			}
+		}
+		if len(log.ReturnData) > 0 {
+			fmt.Fprintln(writer, "ReturnData:")
+			fmt.Fprint(writer, hex.Dump(log.ReturnData))
+		}
+		fmt.Fprintln(writer)
+	}
+}
+
+// WriteLogs writes vm logs in a readable format to the given writer
+func WriteLogs(writer io.Writer, logs []*types.Log) {
+	for _, log := range logs {
+		fmt.Fprintf(writer, "LOG%d: %x bn=%d txi=%x\n", len(log.Topics), log.Address, log.BlockNumber, log.TxIndex)
+
+		for i, topic := range log.Topics {
+			fmt.Fprintf(writer, "%08d  %x\n", i, topic)
+		}
+
+		fmt.Fprint(writer, hex.Dump(log.Data))
+		fmt.Fprintln(writer)
+	}
+}
+
+type mdLogger struct {
+	out io.Writer
+	cfg *LogConfig
+}
+
+// NewMarkdownLogger creates a logger which outputs information in a format adapted
+// for human readability, and is also a valid markdown table
+func NewMarkdownLogger(cfg *LogConfig, writer io.Writer) *mdLogger {
+	l := &mdLogger{writer, cfg}
+	if l.cfg == nil {
+		l.cfg = &LogConfig{}
+	}
+	return l
+}
+
+func (t *mdLogger) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) error {
+	if !create {
+		fmt.Fprintf(t.out, "From: `%v`\nTo: `%v`\nData: `0x%x`\nGas: `%d`\nValue `%v` wei\n",
+			from.String(), to.String(),
+			input, gas, value)
+	} else {
+		fmt.Fprintf(t.out, "From: `%v`\nCreate at: `%v`\nData: `0x%x`\nGas: `%d`\nValue `%v` wei\n",
+			from.String(), to.String(),
+			input, gas, value)
+	}
+
+	fmt.Fprintf(t.out, `
+|  Pc   |      Op     | Cost |   Stack   |   RStack  |  Refund |
+|-------|-------------|------|-----------|-----------|---------|
+`)
+	return nil
+}
+
+func (t *mdLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, rStack *ReturnStack, rData []byte, contract *Contract, depth int, err error) error {
+	fmt.Fprintf(t.out, "| %4d  | %10v  |  %3d |", pc, op, cost)
+
+	if !t.cfg.DisableStack {
+		// format stack
+		var a []string
+		for _, elem := range stack.data {
+			a = append(a, fmt.Sprintf("%v", elem.String()))
+		}
+		b := fmt.Sprintf("[%v]", strings.Join(a, ","))
+		fmt.Fprintf(t.out, "%10v |", b)
+
+		// format return stack
+		a = a[:0]
+		for _, elem := range rStack.data {
+			a = append(a, fmt.Sprintf("%2d", elem))
+		}
+		b = fmt.Sprintf("[%v]", strings.Join(a, ","))
+		fmt.Fprintf(t.out, "%10v |", b)
+	}
+	fmt.Fprintf(t.out, "%10v |", env.StateDB.GetRefund())
+	fmt.Fprintln(t.out, "")
+	if err != nil {
+		fmt.Fprintf(t.out, "Error: %v\n", err)
+	}
+	return nil
+}
+
+func (t *mdLogger) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, rStack *ReturnStack, contract *Contract, depth int, err error) error {
+
+	fmt.Fprintf(t.out, "\nError: at pc=%d, op=%v: %v\n", pc, op, err)
+
+	return nil
+}
+
+func (t *mdLogger) CaptureEnd(output []byte, gasUsed uint64, tm time.Duration, err error) error {
+	fmt.Fprintf(t.out, "\nOutput: `0x%x`\nConsumed gas: `%d`\nError: `%v`\n",
+		output, gasUsed, err)
+	return nil
+}

--- a/docs/notes/instrumentation_measurement/geth/instrumenter/instrumenter.go
+++ b/docs/notes/instrumentation_measurement/geth/instrumenter/instrumenter.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package vm
+package instrumenter
 
 import (
 	"encoding/hex"
@@ -22,13 +22,13 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -46,7 +46,7 @@ func (s Storage) Copy() Storage {
 	return cpy
 }
 
-// LogConfig are the configuration options for structured logger the EVM
+// LogConfig are the configuration options for structured logger the vm.EVM
 type LogConfig struct {
 	DisableMemory     bool // disable memory capture
 	DisableStack      bool // disable stack capture
@@ -60,22 +60,16 @@ type LogConfig struct {
 
 //go:generate gencodec -type StructLog -field-override structLogMarshaling -out gen_structlog.go
 
-// StructLog is emitted to the EVM each cycle and lists information about the current internal state
+// StructLog is emitted to the vm.EVM each cycle and lists information about the current internal state
 // prior to the execution of the statement.
 type StructLog struct {
-	Pc            uint64                      `json:"pc"`
-	Op            OpCode                      `json:"op"`
-	Gas           uint64                      `json:"gas"`
-	GasCost       uint64                      `json:"gasCost"`
-	Memory        []byte                      `json:"memory"`
-	MemorySize    int                         `json:"memSize"`
-	Stack         []*big.Int                  `json:"stack"`
-	ReturnStack   []uint32                    `json:"returnStack"`
-	ReturnData    []byte                      `json:"returnData"`
-	Storage       map[common.Hash]common.Hash `json:"-"`
-	Depth         int                         `json:"depth"`
-	RefundCounter uint64                      `json:"refund"`
-	Err           error                       `json:"-"`
+	Pc            uint64    `json:"pc"`
+	Op            vm.OpCode `json:"op"`
+	Gas           uint64    `json:"gas"`
+	GasCost       uint64    `json:"gasCost"`
+	Depth         int       `json:"depth"`
+	RefundCounter uint64    `json:"refund"`
+	Err           error     `json:"-"`
 }
 
 // overrides for gencodec
@@ -103,19 +97,7 @@ func (s *StructLog) ErrorString() string {
 	return ""
 }
 
-// Tracer is used to collect execution traces from an EVM transaction
-// execution. CaptureState is called for each step of the VM with the
-// current VM state.
-// Note that reference types are actual VM data structures; make copies
-// if you need to retain them beyond the current call.
-type Tracer interface {
-	CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) error
-	CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, rStack *ReturnStack, rData []byte, contract *Contract, depth int, err error) error
-	CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, rStack *ReturnStack, contract *Contract, depth int, err error) error
-	CaptureEnd(output []byte, gasUsed uint64, t time.Duration, err error) error
-}
-
-// StructLogger is an EVM state logger and implements Tracer.
+// StructLogger is an vm.EVM state logger and implements Tracer.
 //
 // StructLogger can capture state based on the given Log configuration and also keeps
 // a track record of modified storage which is used in reporting snapshots of the
@@ -148,70 +130,20 @@ func (l *StructLogger) CaptureStart(from common.Address, to common.Address, crea
 // CaptureState logs a new structured log message and pushes it out to the environment
 //
 // CaptureState also tracks SLOAD/SSTORE ops to track storage change.
-func (l *StructLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, rStack *ReturnStack, rData []byte, contract *Contract, depth int, err error) error {
+func (l *StructLogger) CaptureState(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, memory *vm.Memory, stack *vm.Stack, rStack *vm.ReturnStack, rData []byte, contract *vm.Contract, depth int, err error) error {
 	// check if already accumulated the specified number of logs
 	if l.cfg.Limit != 0 && l.cfg.Limit <= len(l.logs) {
 		return errTraceLimitReached
 	}
-	// Copy a snapshot of the current memory state to a new buffer
-	var mem []byte
-	if !l.cfg.DisableMemory {
-		mem = make([]byte, len(memory.Data()))
-		copy(mem, memory.Data())
-	}
-	// Copy a snapshot of the current stack state to a new buffer
-	var stck []*big.Int
-	if !l.cfg.DisableStack {
-		stck = make([]*big.Int, len(stack.Data()))
-		for i, item := range stack.Data() {
-			stck[i] = new(big.Int).Set(item.ToBig())
-		}
-	}
-	var rstack []uint32
-	if !l.cfg.DisableStack && rStack != nil {
-		rstck := make([]uint32, len(rStack.data))
-		copy(rstck, rStack.data)
-	}
-	// Copy a snapshot of the current storage to a new container
-	var storage Storage
-	if !l.cfg.DisableStorage {
-		// initialise new changed values storage container for this contract
-		// if not present.
-		if l.storage[contract.Address()] == nil {
-			l.storage[contract.Address()] = make(Storage)
-		}
-		// capture SLOAD opcodes and record the read entry in the local storage
-		if op == SLOAD && stack.len() >= 1 {
-			var (
-				address = common.Hash(stack.data[stack.len()-1].Bytes32())
-				value   = env.StateDB.GetState(contract.Address(), address)
-			)
-			l.storage[contract.Address()][address] = value
-		}
-		// capture SSTORE opcodes and record the written entry in the local storage.
-		if op == SSTORE && stack.len() >= 2 {
-			var (
-				value   = common.Hash(stack.data[stack.len()-2].Bytes32())
-				address = common.Hash(stack.data[stack.len()-1].Bytes32())
-			)
-			l.storage[contract.Address()][address] = value
-		}
-		storage = l.storage[contract.Address()].Copy()
-	}
-	var rdata []byte
-	if !l.cfg.DisableReturnData {
-		rdata = make([]byte, len(rData))
-		copy(rdata, rData)
-	}
-	// create a new snapshot of the EVM.
-	log := StructLog{pc, op, gas, cost, mem, memory.Len(), stck, rstack, rdata, storage, depth, env.StateDB.GetRefund(), err}
+	// create a new snapshot of the vm.EVM.
+	log := StructLog{pc, op, gas, cost, depth, env.StateDB.GetRefund(), err}
 	l.logs = append(l.logs, log)
 	return nil
 }
 
 // CaptureFault implements the Tracer interface to trace an execution fault
 // while running an opcode.
-func (l *StructLogger) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, rStack *ReturnStack, contract *Contract, depth int, err error) error {
+func (l *StructLogger) CaptureFault(env *vm.EVM, pc uint64, op vm.OpCode, gas, cost uint64, memory *vm.Memory, stack *vm.Stack, rStack *vm.ReturnStack, contract *vm.Contract, depth int, err error) error {
 	return nil
 }
 
@@ -246,32 +178,6 @@ func WriteTrace(writer io.Writer, logs []StructLog) {
 		}
 		fmt.Fprintln(writer)
 
-		if len(log.Stack) > 0 {
-			fmt.Fprintln(writer, "Stack:")
-			for i := len(log.Stack) - 1; i >= 0; i-- {
-				fmt.Fprintf(writer, "%08d  %x\n", len(log.Stack)-i-1, math.PaddedBigBytes(log.Stack[i], 32))
-			}
-		}
-		if len(log.ReturnStack) > 0 {
-			fmt.Fprintln(writer, "ReturnStack:")
-			for i := len(log.Stack) - 1; i >= 0; i-- {
-				fmt.Fprintf(writer, "%08d  0x%x (%d)\n", len(log.Stack)-i-1, log.ReturnStack[i], log.ReturnStack[i])
-			}
-		}
-		if len(log.Memory) > 0 {
-			fmt.Fprintln(writer, "Memory:")
-			fmt.Fprint(writer, hex.Dump(log.Memory))
-		}
-		if len(log.Storage) > 0 {
-			fmt.Fprintln(writer, "Storage:")
-			for h, item := range log.Storage {
-				fmt.Fprintf(writer, "%x: %x\n", h, item)
-			}
-		}
-		if len(log.ReturnData) > 0 {
-			fmt.Fprintln(writer, "ReturnData:")
-			fmt.Fprint(writer, hex.Dump(log.ReturnData))
-		}
 		fmt.Fprintln(writer)
 	}
 }
@@ -288,78 +194,4 @@ func WriteLogs(writer io.Writer, logs []*types.Log) {
 		fmt.Fprint(writer, hex.Dump(log.Data))
 		fmt.Fprintln(writer)
 	}
-}
-
-type mdLogger struct {
-	out io.Writer
-	cfg *LogConfig
-}
-
-// NewMarkdownLogger creates a logger which outputs information in a format adapted
-// for human readability, and is also a valid markdown table
-func NewMarkdownLogger(cfg *LogConfig, writer io.Writer) *mdLogger {
-	l := &mdLogger{writer, cfg}
-	if l.cfg == nil {
-		l.cfg = &LogConfig{}
-	}
-	return l
-}
-
-func (t *mdLogger) CaptureStart(from common.Address, to common.Address, create bool, input []byte, gas uint64, value *big.Int) error {
-	if !create {
-		fmt.Fprintf(t.out, "From: `%v`\nTo: `%v`\nData: `0x%x`\nGas: `%d`\nValue `%v` wei\n",
-			from.String(), to.String(),
-			input, gas, value)
-	} else {
-		fmt.Fprintf(t.out, "From: `%v`\nCreate at: `%v`\nData: `0x%x`\nGas: `%d`\nValue `%v` wei\n",
-			from.String(), to.String(),
-			input, gas, value)
-	}
-
-	fmt.Fprintf(t.out, `
-|  Pc   |      Op     | Cost |   Stack   |   RStack  |  Refund |
-|-------|-------------|------|-----------|-----------|---------|
-`)
-	return nil
-}
-
-func (t *mdLogger) CaptureState(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, rStack *ReturnStack, rData []byte, contract *Contract, depth int, err error) error {
-	fmt.Fprintf(t.out, "| %4d  | %10v  |  %3d |", pc, op, cost)
-
-	if !t.cfg.DisableStack {
-		// format stack
-		var a []string
-		for _, elem := range stack.data {
-			a = append(a, fmt.Sprintf("%v", elem.String()))
-		}
-		b := fmt.Sprintf("[%v]", strings.Join(a, ","))
-		fmt.Fprintf(t.out, "%10v |", b)
-
-		// format return stack
-		a = a[:0]
-		for _, elem := range rStack.data {
-			a = append(a, fmt.Sprintf("%2d", elem))
-		}
-		b = fmt.Sprintf("[%v]", strings.Join(a, ","))
-		fmt.Fprintf(t.out, "%10v |", b)
-	}
-	fmt.Fprintf(t.out, "%10v |", env.StateDB.GetRefund())
-	fmt.Fprintln(t.out, "")
-	if err != nil {
-		fmt.Fprintf(t.out, "Error: %v\n", err)
-	}
-	return nil
-}
-
-func (t *mdLogger) CaptureFault(env *EVM, pc uint64, op OpCode, gas, cost uint64, memory *Memory, stack *Stack, rStack *ReturnStack, contract *Contract, depth int, err error) error {
-
-	fmt.Fprintf(t.out, "\nError: at pc=%d, op=%v: %v\n", pc, op, err)
-
-	return nil
-}
-
-func (t *mdLogger) CaptureEnd(output []byte, gasUsed uint64, tm time.Duration, err error) error {
-	fmt.Fprintf(t.out, "\nOutput: `0x%x`\nConsumed gas: `%d`\nError: `%v`\n",
-		output, gasUsed, err)
-	return nil
 }

--- a/docs/notes/instrumentation_measurement/geth/main.go
+++ b/docs/notes/instrumentation_measurement/geth/main.go
@@ -34,7 +34,7 @@ func main() {
 	retWarmUp, _, errWarmUp := runtime.Execute(bytecode, nil, cfg)
 
 	cfg.EVMConfig.Debug = true
-	tracer := instrumenter.NewStructLogger(nil)
+	tracer := instrumenter.NewInstrumenterLogger(nil)
 	cfg.EVMConfig.Tracer = tracer
 
 	sampleStart := time.Now()
@@ -60,7 +60,7 @@ func main() {
 	fmt.Println("Return:", retWarmUp)
 	fmt.Println(sampleDuration)
 
-	structLogs := tracer.StructLogs()
+	structLogs := tracer.InstrumenterLogs()
 	instrumenter.WriteTrace(os.Stdout, structLogs)
 
 }

--- a/docs/notes/instrumentation_measurement/geth/main.go
+++ b/docs/notes/instrumentation_measurement/geth/main.go
@@ -10,10 +10,11 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/core/vm/runtime"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
+
+	"./instrumenter"
 )
 
 func main() {
@@ -33,7 +34,7 @@ func main() {
 	retWarmUp, _, errWarmUp := runtime.Execute(bytecode, nil, cfg)
 
 	cfg.EVMConfig.Debug = true
-	tracer := vm.NewStructLogger(nil)
+	tracer := instrumenter.NewStructLogger(nil)
 	cfg.EVMConfig.Tracer = tracer
 
 	sampleStart := time.Now()
@@ -60,7 +61,7 @@ func main() {
 	fmt.Println(sampleDuration)
 
 	structLogs := tracer.StructLogs()
-	vm.WriteTrace(os.Stdout, structLogs)
+	instrumenter.WriteTrace(os.Stdout, structLogs)
 
 }
 

--- a/docs/notes/instrumentation_measurement/geth/main.go
+++ b/docs/notes/instrumentation_measurement/geth/main.go
@@ -31,14 +31,17 @@ func main() {
 	cfg := new(runtime.Config)
 	setDefaults(cfg)
 
-	retWarmUp, _, errWarmUp := runtime.Execute(bytecode, nil, cfg)
-
+	// Warm-up. **NOTE** we're keeping tracing on during warm-up, otherwise measurements are off
 	cfg.EVMConfig.Debug = true
 	tracer := instrumenter.NewInstrumenterLogger(nil)
 	cfg.EVMConfig.Tracer = tracer
+	retWarmUp, _, errWarmUp := runtime.Execute(bytecode, nil, cfg)
+	// End warm-up
 
 	sampleStart := time.Now()
 	for i := 0; i < sampleSize; i++ {
+		tracer = instrumenter.NewInstrumenterLogger(nil)
+		cfg.EVMConfig.Tracer = tracer
 		go_runtime.GC()
 		start := time.Now()
 		_, _, err := runtime.Execute(bytecode, nil, cfg)
@@ -49,6 +52,9 @@ func main() {
 		}
 		if printEach {
 			fmt.Println(duration.Nanoseconds())
+
+			structLogs := tracer.InstrumenterLogs()
+			instrumenter.WriteTrace(os.Stdout, structLogs)
 		}
 	}
 
@@ -59,9 +65,6 @@ func main() {
 	}
 	fmt.Println("Return:", retWarmUp)
 	fmt.Println(sampleDuration)
-
-	structLogs := tracer.InstrumenterLogs()
-	instrumenter.WriteTrace(os.Stdout, structLogs)
 
 }
 


### PR DESCRIPTION
Closes #3 

This leaves the geth instrumentation & measurement in the following state:
  - you can instrument a provided bytecode and dump wall clock time of every instruction, with repetitions and some basic handling of overhead & warm up problems
  - lots of notes (please review `geth.md` in its entirety

The `geth.md` file includes a list of follow-up tasks to do to expand this.