### PR TITLE
Add measurement_standard_ruleset.md for measure_all

### DIFF
--- a/docs/notes/execution_comparison.md
+++ b/docs/notes/execution_comparison.md
@@ -11,15 +11,14 @@ For now, we focus on the individual OPCODE measurements, which we used in prelim
 ### Notes
 
 1. `geth` incorporates a lot of setup which gets measured along with the _first_ instruction. Later this is worked around for programs, where only a single instruction is interesting, by prepending a throw-away `PUSH1`, wherever the interesting instructions would be the first one. `evmone` and `OpenEthereum` don't have this.
-    - **TODO** this should be fixed by moving the `CaptureStart` in a forked `go-ethereum` implementation. It should be placed deeper down the call stack, just before entering the first interpreter loop iteration
-2. In order to ensure standardization and portability, easy and succinct rules of how to measure should be devised, so that such comparisons aren't necessary in the future. First draft (**TODO** polish out):
-    - always measure the entire block of code which constitutes a single interpreter iteration
-    - leave all preprocessing out
-    - make sure all tracing/debugging is off, except what we need to trace. **TODO** `geth` measurement should be improved in this aspect, possibly move away from leveraging the `Tracer` interface
-    - gather the measurements consistently. There should be no allocations done
-    - look into whether preprocessing or similar optimizations don't "move effort" from one instruction to another, like `evmone` does
+    - this should be fixed by moving the `CaptureStart` in a forked `go-ethereum` implementation. It should be placed deeper down the call stack, just before entering the first interpreter loop iteration
+    - **EDIT**: this has been solved differently: we modify the interpreter code
+2. In order to ensure standardization and portability, easy and succinct rules of how to measure should be devised, so that such comparisons aren't necessary in the future. See [Measurement standard ruleset](measurement_standard_ruleset.md):
 3. `evmone` does a preprocessing step `analysis.cpp`, which slightly skews measurements - some of the effort to do some OPCODEs will be "put" under "intrinsic OPCODE `BEGINBLOCK`" executing at the end of each code block. `geth` and `OpenEthereum` don't have this.
     - `BEGINBLOCK` (manifesting as `JUMPDEST` in OPCODE tracing) needs special attention in larger programs. We must come up with a way to handle it, since other implementations will not have this "intrinsic instruction". **TODO**
 4. `evmone` perceivably measures _only_ the execution of the OPCODE (as opposed to `geth`), but this is not the case. In `evmone` all logic done in the main interpreter loop in `geth` is done deeper down the call stack.
-5. `OpenEthereum` excludes the `while` loop condition used in the interpreter loop (`geth` and `evmone` include it). Similar fix for this for `evmone` has been done [here](https://github.com/imapp-pl/evmone/pull/2). [See also here](./instrumentation_measurement/openethereum.md)
-5. `geth` and `evmone` measurements are written to a pre-allocated array on every instruction, while `OpenEthereum` write the CSV data straight to `stdout`, this might be slightly unfair **TODO** even out the measurement implementations
+5. ~`OpenEthereum` excludes the `while` loop condition used in the interpreter loop (`geth` and `evmone` include it)~ 
+  - **EDIT**: done for `evmone` [here](https://github.com/imapp-pl/evmone/pull/2)
+  - **EDIT**: done for `openethereum` [here](...)
+5. `geth` and `evmone` measurements are written to a pre-allocated array on every instruction, ~while `OpenEthereum` write the CSV data straight to `stdout`, this might be slightly unfair~
+  - **EDIT**: done for `openethereum` [here](...)

--- a/docs/notes/measurement_standard_ruleset.md
+++ b/docs/notes/measurement_standard_ruleset.md
@@ -1,0 +1,62 @@
+## Measurement standard ruleset
+
+In order to ensure easy portability and adaptability to various clients and environments, we write down a ruleset of how should OPCODE measurements be conducted
+
+### `measure_all`
+
+In `measure_all` we measure the time of all OPCODEs exectued for a given program.
+We also measure the timer overhead alongside the OPCODE execution measurement.
+
+It turned out to be much better to measure by applying crude modifications to the EVM interpreter code, than to measure via calling a callback (e.g. `Tracer.CaptureState` for `geth`).
+To make this easier and as uniform as possible, follow these guidelines:
+
+1. Measure the entire block of code which constitutes a single interpreter iteration. In particular, measure all code which is repeatedly executed as OPCODEs are interpreted.
+2. Leave all preprocessing out.
+3. Make sure all tracing/debugging is off, except what we need to trace.
+4. Gather the measurements consistently. There should be no allocations done by the measurement code.
+5. Measurements should be gathered in a pre-allocated collection.
+6. Don't do IO (`println` etc.) in the loop.
+7. Look into whether preprocessing or similar optimizations don't "move effort" from one instruction to another, like `evmone` does. If so, analyze impact and unfairness.
+8. Use timer with least overhead, the most low-level one available.
+9. When measuring the timer overhead, capture the time in exactly same way as done for the OPCODE measurement.
+
+Follow this pseudocode pattern:
+
+```go
+// all preparations/allocations of the EVM code
+// instrumentation preparations/allocations
+start_time = now()
+while {
+    // EVM code
+    // OPCODE code etc...
+    
+    switch some_end_conditions {
+        continue: 
+            // EVM code
+            end_time = now()
+            // measure the timer overhead
+            end_timer_time = now()
+            opcode_duration = end_time - start_time
+            timer_duration = end_timer_time - end_time
+
+            durations.store_with_no_allocations(opcode_duration, timer_duration)
+            start_time = now()
+        break:
+            // EVM code
+            end_time = now()
+            // measure the timer overhead
+            end_timer_time = now()
+            opcode_duration = end_time - start_time
+            timer_duration = end_timer_time - end_time
+
+            durations.store_with_no_allocations(opcode_duration, timer_duration)
+            // let it break normally
+    }
+}
+
+durations.print()
+```
+
+
+
+


### PR DESCRIPTION
As title, adds a file describing the rules followed when doing measure_all.

measure_total and other ways will be done separately.