### PR TITLE
Include openethereum comparison

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,11 @@
 src/instrumentation_measurement/openethereum/ethcore/res/wasm-tests
 src/instrumentation_measurement/openethereum/ethcore/res/ethereum/tests
+src/instrumentation_measurement/openethereum/crates/ethcore/res/json_tests
 src/instrumentation_measurement/openethereum/target
 
 src/instrumentation_measurement/evmone/build
 
 /.dockerignore
 /Dockerfile*
+
+.git

--- a/Dockerfile.openethereum
+++ b/Dockerfile.openethereum
@@ -16,7 +16,7 @@ RUN pip3 install -r src/program_generator/requirements.txt
 # get our files for openethereum
 # NOTE: we don't do `RUN git submodule update --init --recursive`. You should do this in the host
 COPY ./src/instrumentation_measurement/openethereum /srv/app/src/instrumentation_measurement/openethereum
-WORKDIR /srv/app/src/instrumentation_measurement/openethereum/evmbin/
+WORKDIR /srv/app/src/instrumentation_measurement/openethereum/bin/evmbin/
 
 RUN cargo build --release
 

--- a/Dockerfile.openethereum
+++ b/Dockerfile.openethereum
@@ -1,15 +1,17 @@
 FROM rust:1.52.0
 
 # RUN apk update && apk add rust cargo yasm cmake
-RUN apt update
+RUN apt update -y
 RUN apt install -y yasm cmake python3-pip
 RUN alias python=python3
+
+RUN pip3 install --upgrade pip
 
 WORKDIR /srv/app/
 
 # base for python
 COPY ./src/program_generator/requirements.txt /srv/app/src/program_generator/requirements.txt
-RUN pip install -r src/program_generator/requirements.txt
+RUN pip3 install -r src/program_generator/requirements.txt
 
 # get our files for openethereum
 # NOTE: we don't do `RUN git submodule update --init --recursive`. You should do this in the host

--- a/Dockerfile.openethereum
+++ b/Dockerfile.openethereum
@@ -1,4 +1,4 @@
-FROM rust:1.55.0
+FROM rust:1.52.0
 
 # RUN apk update && apk add rust cargo yasm cmake
 RUN apt update

--- a/docs/notes/instrumentation_measurement/openethereum.md
+++ b/docs/notes/instrumentation_measurement/openethereum.md
@@ -3,7 +3,7 @@
 
 ### Installation and running
 
-1. To build, run in the `evmbin` directory of openethereum repository (submodule), at branch `wallclock` 
+1. To build, run in the `bin/evmbin` directory of openethereum repository (submodule), at branch `wallclock` 
     ```
     cargo build --release
     ```

--- a/src/analysis/individual_vs_total_validation.Rmd
+++ b/src/analysis/individual_vs_total_validation.Rmd
@@ -112,10 +112,12 @@ setwd("~/sources/imapp/gas-cost-estimator/src")
 
 traces = read.csv(paste("../../local/trace_pg_arythmetic_", program_set_codename, ".csv", sep=""))
 head(traces)
-total_measurements_geth = read.csv(paste("../../local/geth_pg_arythmetic_", program_set_codename, ".csv", sep=""))
+total_measurements_geth = read.csv(paste("../../local/geth_pg_arythmetic_", program_set_codename, "_50_1.csv", sep=""))
 head(total_measurements_geth)
-total_measurements_evmone = read.csv(paste("../../local/evmone_pg_arythmetic_", program_set_codename, ".csv", sep=""))
+total_measurements_evmone = read.csv(paste("../../local/evmone_pg_arythmetic_", program_set_codename, "_50_1.csv", sep=""))
 head(total_measurements_evmone)
+total_measurements_openethereum = read.csv(paste("../../local/openethereum_pg_arythmetic_", program_set_codename, "_50_1.csv", sep=""))
+head(total_measurements_openethereum)
 ```
 
 ### Remove outliers
@@ -134,12 +136,15 @@ total_measurements_geth = remove_outliers(total_measurements_geth, "measure_tota
 head(total_measurements_geth)
 total_measurements_evmone = remove_outliers(total_measurements_evmone, "measure_total_time_ns")
 head(total_measurements_evmone)
+total_measurements_openethereum = remove_outliers(total_measurements_openethereum, "measure_total_time_ns")
+head(total_measurements_openethereum)
 ```
 
 ```{r}
 total_measurements_geth$env = 'geth'
 total_measurements_evmone$env = 'evmone'
-total_measurements = rbind(total_measurements_geth, total_measurements_evmone)
+total_measurements_openethereum$env = 'openethereum'
+total_measurements = rbind(total_measurements_geth, total_measurements_evmone, total_measurements_openethereum)
 head(total_measurements)
 ```
 ### Validation using improved data/method
@@ -216,6 +221,7 @@ overview_plots <- function(df, selection_col, selection_val) {
 }
 overview_plots(total_measurements, 'env', 'geth')
 overview_plots(total_measurements, 'env', 'evmone')
+overview_plots(total_measurements, 'env', 'openethereum')
 ```
 
 Here is a detailed inspection of the "warm-up" profiles for first 40 programs.
@@ -237,6 +243,7 @@ warmup_profile_plots <- function(df, selection_col, selection_val) {
 }
 warmup_profile_plots(total_measurements, 'env', 'geth')
 warmup_profile_plots(total_measurements, 'env', 'evmone')
+warmup_profile_plots(total_measurements, 'env', 'openethereum')
 print("Hide big plots")
 ```
 ### Check estimation using trivial variables
@@ -269,6 +276,7 @@ trivial_variable_plots <- function(df, selection_col, selection_val) {
 }
 trivial_variable_plots(validation, 'env', 'geth')
 trivial_variable_plots(validation, 'env', 'evmone')
+trivial_variable_plots(validation, 'env', 'openethereum')
 ```
 
 ```{r}
@@ -282,6 +290,7 @@ compare_current_gas_cost_plots <- function(df, selection_col, selection_val, est
 }
 compare_current_gas_cost_plots(validation, 'env', 'geth', estimate_variable)
 compare_current_gas_cost_plots(validation, 'env', 'evmone', estimate_variable)
+compare_current_gas_cost_plots(validation, 'env', 'openethereum', estimate_variable)
 ```
 
 Try with the safer subset (no EXP) again, to check how do we compare against the current gas cost.
@@ -292,6 +301,7 @@ Current gas cost is completely off for EXP.
 validation_no_exp = validation[which(validation$has_exp == 'blue'),]
 compare_current_gas_cost_plots(validation_no_exp, 'env', 'geth', estimate_variable)
 compare_current_gas_cost_plots(validation_no_exp, 'env', 'evmone', estimate_variable)
+compare_current_gas_cost_plots(validation_no_exp, 'env', 'openethereum', estimate_variable)
 ```
 
 ### Final validation model
@@ -299,10 +309,13 @@ compare_current_gas_cost_plots(validation_no_exp, 'env', 'evmone', estimate_vari
 ```{r}
 model_geth = lm_validation(validation, explained_variable, estimate_variable, selection_col='env', selection_val='geth')
 model_evmone = lm_validation(validation, explained_variable, estimate_variable, selection_col='env', selection_val='evmone')
+model_openethereum = lm_validation(validation, explained_variable, estimate_variable, selection_col='env', selection_val='openethereum')
 print('geth')
 summary(model_geth)
 print('evmone')
 summary(model_evmone)
+print('openethereum')
+summary(model_openethereum)
 ```
 
 #### Model coefficients: discussion
@@ -354,15 +367,20 @@ We would be expecting it be closer to `1`, excluding `EXP` doesn't help much in 
 
 compare_current_gas_cost_plots(validation, 'env', 'geth', 'marginal_cost')
 compare_current_gas_cost_plots(validation, 'env', 'evmone', 'marginal_cost')
+compare_current_gas_cost_plots(validation, 'env', 'openethereum', 'marginal_cost')
 compare_current_gas_cost_plots(validation_no_exp, 'env', 'geth', 'marginal_cost')
 compare_current_gas_cost_plots(validation_no_exp, 'env', 'evmone', 'marginal_cost')
+compare_current_gas_cost_plots(validation_no_exp, 'env', 'openethereum', 'marginal_cost')
 
 model_geth_marginal = lm_validation(validation, explained_variable, 'marginal_cost', selection_col='env', selection_val='geth')
 model_evmone_marginal = lm_validation(validation, explained_variable, 'marginal_cost', selection_col='env', selection_val='evmone')
+model_openethereum_marginal = lm_validation(validation, explained_variable, 'marginal_cost', selection_col='env', selection_val='openethereum')
 print('geth')
 summary(model_geth_marginal)
 print('evmone')
 summary(model_evmone_marginal)
+print('openethereum')
+summary(model_openethereum_marginal)
 ```
 
 Comparison models excluding `EXP` - no strange intercept for `geth` anymore.
@@ -371,15 +389,17 @@ We probably must parametrize `EXP` arguments carefully.
 ```{r}
 summary(lm_validation(validation_no_exp, explained_variable, 'marginal_cost', selection_col='env', selection_val='geth'))
 summary(lm_validation(validation_no_exp, explained_variable, 'marginal_cost', selection_col='env', selection_val='evmone'))
+summary(lm_validation(validation_no_exp, explained_variable, 'marginal_cost', selection_col='env', selection_val='openethereum'))
 ```
 
-Compare OPCODE estimates from both methods directly
+Compare OPCODE estimates from both methods directly (`openethereum` is missing some data so disabled.)
 
 ```{r fig.width=14}
 estimate_comparison = sqldf("SELECT estimated_cost.*, marginal_estimated_cost.estimate_marginal_ns
                              FROM marginal_estimated_cost
                              LEFT JOIN estimated_cost ON estimated_cost.op = marginal_estimated_cost.op
-                                  AND estimated_cost.env = marginal_estimated_cost.env")
+                                  AND estimated_cost.env = marginal_estimated_cost.env
+                             WHERE estimated_cost.env != 'openethereum'")
 head(estimate_comparison)
 scatter.smooth(estimate_comparison$estimate_marginal_ns ~ estimate_comparison$min, log="xy")
 text(estimate_comparison$estimate_marginal_ns ~ estimate_comparison$min, labels=paste(estimate_comparison$op, estimate_comparison$env), cex=0.6, pos=1, font=2)
@@ -467,6 +487,12 @@ print('evmone, marginal_cost')
 summary(lm_validation(validation_no_exp, explained_variable, 'marginal_cost', selection_col='env', selection_val='evmone'))
 print('evmone, gas schedule')
 summary(lm_validation(validation_no_exp, explained_variable, 'current_gas_cost', selection_col='env', selection_val='evmone'))
+print('openethereum, our estimate')
+summary(lm_validation(validation_no_exp, explained_variable, estimate_variable, selection_col='env', selection_val='openethereum'))
+print('openethereum, marginal_cost')
+summary(lm_validation(validation_no_exp, explained_variable, 'marginal_cost', selection_col='env', selection_val='openethereum'))
+print('openethereum, gas schedule')
+summary(lm_validation(validation_no_exp, explained_variable, 'current_gas_cost', selection_col='env', selection_val='openethereum'))
 ```
 ## Model diagnostics
 
@@ -477,9 +503,11 @@ The linear model metrics are reasonable. Things to watch out for:
 The diagnosticts look decent.
 
 ```{r fig.width=15}
-par(mfrow=c(4,4))
+par(mfrow=c(6,4))
 plot(model_geth)
 plot(model_evmone)
+plot(model_openethereum)
 plot(model_geth_marginal)
 plot(model_evmone_marginal)
+plot(model_openethereum_marginal)
 ```

--- a/src/analysis/measure_arguments.Rmd
+++ b/src/analysis/measure_arguments.Rmd
@@ -62,7 +62,8 @@ measurement_codename = "50_1"
 
 result_geth = load_data_set("geth", program_set_codename, measurement_codename)
 result_evmone = load_data_set("evmone", program_set_codename, measurement_codename)
-results = rbind(result_evmone, result_geth)
+result_openethereum = load_data_set("openethereum", program_set_codename, measurement_codename)
+results = rbind(result_evmone, result_geth, result_openethereum)
 head(results)
 ```
 
@@ -74,6 +75,7 @@ measurements = sqldf("SELECT opcode, op_count, arg0, arg1, arg2, sample_id, run_
                      ")
 head(measurements)
 ```
+
 ```{r}
 remove_outliers <- function(df, col) {
   boxplot_result = boxplot(df[, col] ~ df[, 'op_count'] + df[, 'env'] + df[, 'opcode'], plot=FALSE)
@@ -91,12 +93,14 @@ if (removed_outliers) {
   # before
   boxplot(measure_total_time_ns ~ opcode, data=measurements[which(measurements$env == 'geth'), ], las=2, outline=TRUE, log='y')
   boxplot(measure_total_time_ns ~ opcode, data=measurements[which(measurements$env == 'evmone'), ], las=2, outline=TRUE, log='y')
+  boxplot(measure_total_time_ns ~ opcode, data=measurements[which(measurements$env == 'openethereum'), ], las=2, outline=TRUE, log='y')
 
   measurements = remove_outliers(measurements, 'measure_total_time_ns')
   
   # after
   boxplot(measure_total_time_ns ~ opcode, data=measurements[which(measurements$env == 'geth'), ], las=2, outline=TRUE, log='y')
   boxplot(measure_total_time_ns ~ opcode, data=measurements[which(measurements$env == 'evmone'), ], las=2, outline=TRUE, log='y')
+  boxplot(measure_total_time_ns ~ opcode, data=measurements[which(measurements$env == 'openethereum'), ], las=2, outline=TRUE, log='y')
 }
 ```
 
@@ -124,7 +128,7 @@ unary_opcodes = extract_opcodes(program_set_codename, 1)
 binary_opcodes = extract_opcodes(program_set_codename, 2)
 ternary_opcodes = extract_opcodes(program_set_codename, 3)
 
-all_envs = c('geth', 'evmone')
+all_envs = c('geth', 'evmone', 'openethereum')
 ```
 ### Models
 
@@ -207,6 +211,7 @@ analyze_for_env <- function(df, results_df, env) {
 
 first_pass = analyze_for_env(measurements, first_pass, 'geth')
 first_pass = analyze_for_env(measurements, first_pass, 'evmone')
+first_pass = analyze_for_env(measurements, first_pass, 'openethereum')
 
 proceed_with_opcodes = unique(first_pass[which(first_pass$has_impacting == 'TRUE'), 'opcode'])
 
@@ -234,9 +239,6 @@ validation_plot <- function(df, opcode, env, argcol) {
   par(mfrow=c(1,1))
   boxplot(as.formula(paste('measure_total_time_ns ~ ', argcol, sep='')), data=df[which(df$opcode==opcode & df$env==env & df$op_count==max(df$op_count)), ])
 }
-
-# just an example, will use more further down below
-validation_plot(measurements, 'DIV', 'geth', 'arg1')
 ```
 
 ### Model with all variables ever

--- a/src/analysis/measure_arguments.Rmd
+++ b/src/analysis/measure_arguments.Rmd
@@ -62,7 +62,7 @@ measurement_codename = "50_1"
 
 result_geth = load_data_set("geth", program_set_codename, measurement_codename)
 result_evmone = load_data_set("evmone", program_set_codename, measurement_codename)
-result_openethereum = load_data_set("openethereum", program_set_codename, measurement_codename)
+result_openethereum = load_data_set("openethereum", program_set_codename, "200_2")
 results = rbind(result_evmone, result_geth, result_openethereum)
 head(results)
 ```

--- a/src/analysis/measure_marginal.Rmd
+++ b/src/analysis/measure_marginal.Rmd
@@ -247,10 +247,36 @@ estimates = estimates[which(estimates$env != 'geth'), ]
 programs = programs_for_compute("arithmetic_comb_c50_shuffle")
 results = load_data_set("geth", "arithmetic_comb_c50_shuffle", "total_50_4")
 for (opcode in all_opcodes) {
-  estimate = compute_all(programs, results, opcode, "geth", TRUE, mod_op_count=5)
+  estimate = compute_all(programs, results, opcode, "geth", TRUE)
   estimates[nrow(estimates) + 1, ] = c(opcode, estimate, 'geth')
 }
 ```
+**NOTE** for `openethereum` we need to use programs with 0-200 increasing `op_count`, otherwise the model doesn't capture the trend.
+
+**TODO** To be fully fair, we should do the same for `geth` and `evmone`.
+
+```{r}
+estimates = estimates[which(estimates$env != 'openethereum'), ]
+programs = programs_for_compute("arithmetic_comb_c200_shuffle")
+results = load_data_set("openethereum", "arithmetic_comb_c200_shuffle", "total_50_4")
+for (opcode in all_opcodes) {
+  estimate = compute_all(programs, results, opcode, "openethereum", TRUE)
+  estimates[nrow(estimates) + 1, ] = c(opcode, estimate, 'openethereum')
+}
+```
+Some extra validation tools for `openethereum`. Optional so commented out.
+
+```{r fig.width=20}
+# measurements = sqldf("SELECT opcode, op_count, sample_id, run_id, measure_total_time_ns, env, results.program_id
+#                      FROM results
+#                      INNER JOIN
+#                        programs ON(results.program_id = programs.program_id)")
+# boxplot(measure_total_time_ns ~ op_count + opcode, data=measurements, outline=FALSE)
+# if (removed_outliers) {
+#   measurements = remove_outliers(measurements, 'measure_total_time_ns')
+# }
+```
+
 
 ```{r}
 print(all_opcodes)

--- a/src/analysis/validation_with_arguments.Rmd
+++ b/src/analysis/validation_with_arguments.Rmd
@@ -311,9 +311,15 @@ Results for `geth` and `evmone` look promising, the correlation is clearly there
 
 The worrying part is the intercept coefficient which is far away from zero (should be the cost of an empty EVM program). **NOTE** if we use a validation set with only small arguments (`smallpush`), then the intercept problem goes away, so it seems that it might be coming from the estimates of the arguments impact.
 
+#### `openethereum` problem
+
+**NOTE** this has been solved, see last paragraph.
+
 `openethereum` has very bad results, the slope coefficient isn't even significant. If we use `smallpush` it becomes significant around 0.55. `marginal` and `individual` measurements actually yield much better validation models (see `individual_vs_total_validation.Rmd` which explores that) than `arguments` measurement. It is likely up to the problems identified during the `arguments` measurement analysis for `openethereum`, namely:
 1. The `OPCODE`s which turn out to have significant and impactful arguments are "weird", e.g. `BYTE` is impacted by both it's arguments, `DIV`-like OPCODEs have surprisingly small impact, `XOR` etc.
 
 There's an interesting phenomenon on the `openethereum` validation, if you use `smallpush` - the validation time seems to be very "bimodal" - there's a gap between two clusters of points - one cluster is overestimated and the other cluster is underestimated. Very few points estimate "on point". It is also observable during manual trials of the measurements - some complete much faster than the others.
 
 Another note is that increasing sample size and/or number of samples for the validation set, improves the validation model. It might be that we're brute-forcing over the problem of the unstability of `openethereum`'s performance (see above).
+
+Lastly, increasing the sample size on the estimation set (`marginal/arguments`), improves the validation model further, and also makes the estimates much "less weird". Only `SHR` remains weird.

--- a/src/analysis/validation_with_arguments.Rmd
+++ b/src/analysis/validation_with_arguments.Rmd
@@ -29,6 +29,7 @@ count_zero_args <- function(x) {
 
 ```{r}
 explained_variable = 'avg_measure_total_time_ns'
+all_envs = c('geth', 'evmone', 'openethereum')
 ```
 
 ```{r}
@@ -62,12 +63,10 @@ estimated_cost = read.csv("../../local/argument_estimated_cost.csv")
 # from measure_marginal.Rmd
 # TODO we need this to fill in missing PUSHes and POP, to be rectified later
 marginal = read.csv("../../local/marginal_estimated_cost.csv")
-# FIXME we drop the openethereum measurements which are not yet ready
-estimated_cost = estimated_cost[-which(estimated_cost$env=='openethereum'), ]
 
 # TODO remove when rectified
 for (opcode in c('PUSH1', 'POP')) {
-  for (env in c('geth', 'evmone')) {
+  for (env in all_envs) {
     # working around the ridiculous type coercion of `c()`
     estimated_cost[nrow(estimated_cost) + 1, 1:2] = c(opcode, env)
     estimated_cost[nrow(estimated_cost), 3:4] = c(FALSE, FALSE)
@@ -114,12 +113,18 @@ setwd("~/sources/imapp/gas-cost-estimator/src")
 program_set_codename = "c100_ops300_clean"
 measurement_codename = "200_8"
 
+# this is the data set without varying argument size. 
+# program_set_codename = "c100_ops30_clean_smallpush"
+# measurement_codename = "50_1"
+
 traces = read.csv(paste("../../local/trace_pg_arythmetic_", program_set_codename, ".csv", sep=""))
 head(traces)
 total_measurements_geth = read.csv(paste("../../local/geth_pg_arythmetic_", program_set_codename, "_", measurement_codename, ".csv", sep=""))
 head(total_measurements_geth)
 total_measurements_evmone = read.csv(paste("../../local/evmone_pg_arythmetic_", program_set_codename, "_", measurement_codename, ".csv", sep=""))
 head(total_measurements_evmone)
+total_measurements_openethereum = read.csv(paste("../../local/openethereum_pg_arythmetic_", program_set_codename, "_", measurement_codename, ".csv", sep=""))
+head(total_measurements_openethereum)
 ```
 
 ### Remove outliers
@@ -138,12 +143,15 @@ total_measurements_geth = remove_outliers(total_measurements_geth, "measure_tota
 head(total_measurements_geth)
 total_measurements_evmone = remove_outliers(total_measurements_evmone, "measure_total_time_ns")
 head(total_measurements_evmone)
+total_measurements_openethereum = remove_outliers(total_measurements_openethereum, "measure_total_time_ns")
+head(total_measurements_openethereum)
 ```
 
 ```{r}
 total_measurements_geth$env = 'geth'
 total_measurements_evmone$env = 'evmone'
-total_measurements = rbind(total_measurements_geth, total_measurements_evmone)
+total_measurements_openethereum$env = 'openethereum'
+total_measurements = rbind(total_measurements_geth, total_measurements_evmone, total_measurements_openethereum)
 head(total_measurements)
 ```
 
@@ -224,6 +232,7 @@ overview_plots <- function(df, selection_col, selection_val) {
 }
 overview_plots(total_measurements, 'env', 'geth')
 overview_plots(total_measurements, 'env', 'evmone')
+overview_plots(total_measurements, 'env', 'openethereum')
 ```
 
 ### Check estimation using trivial variables
@@ -256,6 +265,7 @@ trivial_variable_plots <- function(df, selection_col, selection_val) {
 }
 trivial_variable_plots(validation, 'env', 'geth')
 trivial_variable_plots(validation, 'env', 'evmone')
+trivial_variable_plots(validation, 'env', 'openethereum')
 ```
 ### Final validation model
 
@@ -268,15 +278,19 @@ compare_plots <- function(df, selection_col, selection_val, estimate_var) {
 
 model_geth = lm_validation(validation, explained_variable, 'cost_ns', selection_col='env', selection_val='geth')
 model_evmone = lm_validation(validation, explained_variable, 'cost_ns', selection_col='env', selection_val='evmone')
+model_openethereum = lm_validation(validation, explained_variable, 'cost_ns', selection_col='env', selection_val='openethereum')
 print('geth')
 summary(model_geth)
 print('evmone')
 summary(model_evmone)
+print('openethereum')
+summary(model_openethereum)
 ```
 
 ```{r}
 compare_plots(validation, 'env', 'geth', 'cost_ns')
 compare_plots(validation, 'env', 'evmone', 'cost_ns')
+compare_plots(validation, 'env', 'openethereum', 'cost_ns')
 ```
 
 ## Model diagnostics
@@ -284,7 +298,8 @@ compare_plots(validation, 'env', 'evmone', 'cost_ns')
 
 
 ```{r fig.width=15}
-par(mfrow=c(2,4))
+par(mfrow=c(3,4))
 plot(model_geth)
 plot(model_evmone)
+plot(model_openethereum)
 ```

--- a/src/analysis/validation_with_arguments.Rmd
+++ b/src/analysis/validation_with_arguments.Rmd
@@ -123,7 +123,8 @@ total_measurements_geth = read.csv(paste("../../local/geth_pg_arythmetic_", prog
 head(total_measurements_geth)
 total_measurements_evmone = read.csv(paste("../../local/evmone_pg_arythmetic_", program_set_codename, "_", measurement_codename, ".csv", sep=""))
 head(total_measurements_evmone)
-total_measurements_openethereum = read.csv(paste("../../local/openethereum_pg_arythmetic_", program_set_codename, "_", measurement_codename, ".csv", sep=""))
+# TODO: at this point, for openethereum we are getting much better (acceptable) results for the sample size 16, nsamples 400, see Discussion section below
+total_measurements_openethereum = read.csv(paste("../../local/openethereum_pg_arythmetic_", program_set_codename, "_", "16_400", ".csv", sep=""))
 head(total_measurements_openethereum)
 ```
 
@@ -303,3 +304,16 @@ plot(model_geth)
 plot(model_evmone)
 plot(model_openethereum)
 ```
+
+### Discussion of results so far
+
+Results for `geth` and `evmone` look promising, the correlation is clearly there, the slope coefficient is very close to 1 (so there's a good correspondence between a nanosecond of measurement and the nanosecond of validation).
+
+The worrying part is the intercept coefficient which is far away from zero (should be the cost of an empty EVM program). **NOTE** if we use a validation set with only small arguments (`smallpush`), then the intercept problem goes away, so it seems that it might be coming from the estimates of the arguments impact.
+
+`openethereum` has very bad results, the slope coefficient isn't even significant. If we use `smallpush` it becomes significant around 0.55. `marginal` and `individual` measurements actually yield much better validation models (see `individual_vs_total_validation.Rmd` which explores that) than `arguments` measurement. It is likely up to the problems identified during the `arguments` measurement analysis for `openethereum`, namely:
+1. The `OPCODE`s which turn out to have significant and impactful arguments are "weird", e.g. `BYTE` is impacted by both it's arguments, `DIV`-like OPCODEs have surprisingly small impact, `XOR` etc.
+
+There's an interesting phenomenon on the `openethereum` validation, if you use `smallpush` - the validation time seems to be very "bimodal" - there's a gap between two clusters of points - one cluster is overestimated and the other cluster is underestimated. Very few points estimate "on point". It is also observable during manual trials of the measurements - some complete much faster than the others.
+
+Another note is that increasing sample size and/or number of samples for the validation set, improves the validation model. It might be that we're brute-forcing over the problem of the unstability of `openethereum`'s performance (see above).

--- a/src/instrumentation_measurement/measurements.py
+++ b/src/instrumentation_measurement/measurements.py
@@ -137,7 +137,7 @@ class Measurements(object):
   def run_openethereum(self, mode, program, sampleSize):
     openethereum_build_path = './instrumentation_measurement/openethereum/target/release/'
     openethereum_main = [openethereum_build_path + 'openethereum-evm']
-    args = ['--measure-mode', mode, '--code', program.bytecode, "--repeat", "{}".format(sampleSize)]
+    args = ['--chain', 'Berlin', '--measure-mode', mode, '--code', program.bytecode, "--repeat", "{}".format(sampleSize)]
     invocation = openethereum_main + args
     result = subprocess.run(invocation, stdout=subprocess.PIPE, universal_newlines=True)
     assert result.returncode == 0


### PR DESCRIPTION
Closes #95 

Including `openethereum` into the pipeline of `marginal/arguments` measurement, which is otherwise very promising, turns out to be problematic.

Without special treatment (increasing samplesize / nsamples), the validation model is not statistically significant. Also the estimates coming out of the `marginal/arguments` method for `openethereum` are "weird".

I'll continue to research this, together with the "intercept problem" #98, as it seems to boil down to some problems with the estimation model and/or with the very large noisiness of `openethereum` EVM performance.

EDIT: [increasing the samples](5f5ac7a) makes it "good enough". The intercept problem still needs to be investigated