### PR TITLE
Precompile the main.go geth measurement binary for faster runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ src/.Rhistory
 __pycache__
 
 *.nb.html
+/src/instrumentation_measurement/bin/geth_main

--- a/Dockerfile.geth
+++ b/Dockerfile.geth
@@ -17,6 +17,7 @@ ENV PATH=$PATH:/usr/local/go/bin
 ENV GOPATH=/srv/app/.go
 ENV GO111MODULE=off
 ENV GOBIN=/srv/app/.go/bin
+ENV GOGC=off
 
 # fixed golang dependencies
 RUN go get github.com/ethereum/go-ethereum
@@ -44,6 +45,7 @@ RUN go get ./geth/...
 
 # get the rest (program generation etc.) 
 COPY ./src/ /srv/app/src/
+RUN go build -o bin/geth_main geth/main.go
 
 WORKDIR /srv/app/
 

--- a/src/instrumentation_measurement/measurements.py
+++ b/src/instrumentation_measurement/measurements.py
@@ -123,7 +123,7 @@ class Measurements(object):
         print(csv_chunk)
 
   def run_geth(self, mode, program, sampleSize):
-    golang_main = ['go', 'run', './instrumentation_measurement/geth/main.go']
+    golang_main = ['./instrumentation_measurement/bin/geth_main']
     args = ['--mode', mode, '--printCSV', '--printEach=false', '--sampleSize={}'.format(sampleSize)]
     bytecode_arg = ['--bytecode', program.bytecode]
     invocation = golang_main + args + bytecode_arg


### PR DESCRIPTION
Go compilation on each sample eats 99% of the time.