### PR TITLE
Fix marginal measurement explanation

### DIFF
--- a/docs/gas-cost-estimator.md
+++ b/docs/gas-cost-estimator.md
@@ -148,7 +148,7 @@ The layout of the `measure_marginal` generated program is an evolution of this t
 | | |
 |-|-|
 | `PUSH1` | `max_op_count` times |
-| `{OPCODE}` | `op_count` times |
+| `{OPCODE, POP}` | `op_count` times |
 | `POP` | `max_op_count - op_count` times |
 
 An `op_count + 1` program differs from an `op_count` program by only a single instance of the `OPCODE` instruction.


### PR DESCRIPTION
Noticed late that one crucial word is missing in the table explaining `measure_marginal`. We are interleaving `POP`s with `OPCODE` in a way that keeps number of `PUSH`es and `POP`s constant for every `op_count`