### PR TITLE
Fix: reports marginal - no outliers bug

### DIFF
--- a/src/analysis/common.R
+++ b/src/analysis/common.R
@@ -42,14 +42,18 @@ remove_outliers <- function(df, col, for_validation) {
     boxplot_result = boxplot(df[, col] ~ df[, 'op_count'] + df[, 'env'] + df[, 'opcode'], plot=FALSE)
   }
   outliers = boxplot_result$out
-  names = boxplot_result$names[boxplot_result$group]
-  if (for_validation) {
-    all_row_identifiers = paste(df[, col], df[, 'program_id'], df[, 'env'], sep='.')
+  if (length(outliers) == 0) {
+    no_outliers <- df
   } else {
-    all_row_identifiers = paste(df[, col], df[, 'op_count'], df[, 'env'], df[, 'opcode'], sep='.')
+    names = boxplot_result$names[boxplot_result$group]
+    if (for_validation) {
+      all_row_identifiers = paste(df[, col], df[, 'program_id'], df[, 'env'], sep='.')
+    } else {
+      all_row_identifiers = paste(df[, col], df[, 'op_count'], df[, 'env'], df[, 'opcode'], sep='.')
+    }
+    outlier_row_identifiers = paste(outliers, names, sep='.')
+    no_outliers = df[-which(all_row_identifiers %in% outlier_row_identifiers), ]
   }
-  outlier_row_identifiers = paste(outliers, names, sep='.')
-  no_outliers = df[-which(all_row_identifiers %in% outlier_row_identifiers), ]
   return(no_outliers)
 }
 

--- a/src/analysis/measure_marginal_single.Rmd
+++ b/src/analysis/measure_marginal_single.Rmd
@@ -37,16 +37,16 @@ The env = `r env`, the programs file =`r params$programs`, the resutls file = `r
 programs = read.csv(params$programs)
 results = load_data_set_from_file(params$results)
 # besu may have additional columns with gc stats
-results = results[, c("program_id", "sample_id", "run_id", "measure_total_time_ns", "measure_total_timer_time_ns", "env")]
+results = results[, c("program_id", "sample_id", "run_id", "total_time_ns")]
 # TODO geth short-circuits zero length programs, resulting in zero timing somehow. Drop these more elegantly, not based on measure_total_time_ns
-results = results[which(results$measure_total_time_ns != 0), ]
+results = results[which(results$total_time_ns != 0), ]
 ```
 
 ```{r}
-measurements = sqldf("SELECT opcode, op_count, sample_id, run_id, measure_total_time_ns, env, results.program_id
+measurements = sqldf(paste0("SELECT opcode, op_count, sample_id, run_id, total_time_ns as measure_total_time_ns, '", env, "' as env, results.program_id
                      FROM results
                      INNER JOIN
-                       programs ON(results.program_id = programs.program_id)")
+                       programs ON(results.program_id = programs.program_id)"))
 measurements$opcode = factor(measurements$opcode, levels=unique(programs$opcode))
 # head(measurements)
 ```


### PR DESCRIPTION
When `removed_outliers` is set to true, the report generation failed.
It is because with no outliers one of the variables changed the type and proceeding condition checks always were failing causing all results to be empty.