### PR TITLE
Fix in pg_marginal for REVERT, RETURN, STOP

### DIFF
--- a/src/program_generator/pg_marginal.py
+++ b/src/program_generator/pg_marginal.py
@@ -209,13 +209,13 @@ def _generate_subcontext_exit_program(operation, op_count, max_op_count):
   no_op_subcontext_code = '60ff60005260026018'
   op_subcontext_code = no_op_subcontext_code + operation['Value'][2:4]
   op_deployment_code = '7269' + op_subcontext_code + '600052600a6016f36000526013600d6000f0'
-  no_op_deployment_code = '7168' + no_op_subcontext_code + '60005260096017f36000526013600d6000f0'
+  no_op_deployment_code = '7168' + no_op_subcontext_code + '60005260096017f36000526012600e6000f0'
 
   op_address_store = '60ff52'
   op_address_load = '60ff51'
 
-  no_op_calls = '60006000602060008461fffff450' * (max_op_count - op_count)
-  op_calls = op_address_load + '60006000602060008461fffff450' * op_count
+  no_op_calls = '60006000600060008461fffff450' * (max_op_count - op_count)
+  op_calls = op_address_load + '60006000600060008461fffff450' * op_count
   
   return op_deployment_code + op_address_store + no_op_deployment_code + no_op_calls + op_address_load + op_calls
         


### PR DESCRIPTION
Due to wrong memory range for no_op deployment the program terminated prematurely.